### PR TITLE
Annotations for 1.5.1 and 11.5.1 to go with 13.1.1

### DIFF
--- a/RWA_C_V2_SDG DSD.xml
+++ b/RWA_C_V2_SDG DSD.xml
@@ -3449,6 +3449,16 @@
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
               <common:AnnotationText xml:lang="en">13.1.1</common:AnnotationText>
             </common:Annotation>
             <common:Annotation>
@@ -3474,6 +3484,16 @@
         </structure:Code>
         <structure:Code id="VC_DSR_AFFCT" urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=NISR-SDGs:CL_SERIES(1.3).VC_DSR_AFFCT">
           <common:Annotations>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
@@ -3505,6 +3525,16 @@
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
               <common:AnnotationText xml:lang="en">13.1.1</common:AnnotationText>
             </common:Annotation>
             <common:Annotation>
@@ -3530,6 +3560,16 @@
         </structure:Code>
         <structure:Code id="VC_DSR_MTMP" urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=NISR-SDGs:CL_SERIES(1.3).VC_DSR_MTMP">
           <common:Annotations>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
@@ -3561,6 +3601,16 @@
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
               <common:AnnotationText xml:lang="en">13.1.1</common:AnnotationText>
             </common:Annotation>
             <common:Annotation>
@@ -3586,6 +3636,16 @@
         </structure:Code>
         <structure:Code id="VC_DSR_DAFF" urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=NISR-SDGs:CL_SERIES(1.3).VC_DSR_DAFF">
           <common:Annotations>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
@@ -3617,6 +3677,16 @@
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
               <common:AnnotationText xml:lang="en">13.1.1</common:AnnotationText>
             </common:Annotation>
             <common:Annotation>
@@ -3642,6 +3712,16 @@
         </structure:Code>
         <structure:Code id="VC_DSR_PDAN" urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=NISR-SDGs:CL_SERIES(1.3).VC_DSR_PDAN">
           <common:Annotations>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
@@ -3673,6 +3753,16 @@
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
               <common:AnnotationText xml:lang="en">13.1.1</common:AnnotationText>
             </common:Annotation>
             <common:Annotation>
@@ -3698,6 +3788,16 @@
         </structure:Code>
         <structure:Code id="VC_DSR_PDYN" urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=NISR-SDGs:CL_SERIES(1.3).VC_DSR_PDYN">
           <common:Annotations>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
@@ -3729,6 +3829,16 @@
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
               <common:AnnotationText xml:lang="en">13.1.1</common:AnnotationText>
             </common:Annotation>
             <common:Annotation>
@@ -3754,6 +3864,16 @@
         </structure:Code>
         <structure:Code id="VC_DSR_PDLN" urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=NISR-SDGs:CL_SERIES(1.3).VC_DSR_PDLN">
           <common:Annotations>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
@@ -3785,6 +3905,16 @@
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
               <common:AnnotationText xml:lang="en">13.1.1</common:AnnotationText>
             </common:Annotation>
             <common:Annotation>
@@ -3813,7 +3943,17 @@
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>
               <common:AnnotationType>Indicator</common:AnnotationType>
-              <common:AnnotationText xml:lang="en">13.1.2</common:AnnotationText>
+              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
+            </common:Annotation>
+            <common:Annotation>
+              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
+              <common:AnnotationType>Indicator</common:AnnotationType>
+              <common:AnnotationText xml:lang="en">13.1.1</common:AnnotationText>
             </common:Annotation>
             <common:Annotation>
               <common:AnnotationTitle>IndicatorCode</common:AnnotationTitle>


### PR DESCRIPTION
This should allow for indicators 1.5.1 and 11.5.1 to display the same data as 13.1.1.

NOTE: This is only a temporary fix, because this will be overwritten the next time that DSD Constructor is used to update the DSD. For reference, here is what I did:

1. Search the DSD for this text: `>13.1.1<`. It occurs several places in the DSD.
2. For each instance I found, I pasted the following above it:
        
            <common:Annotation>
              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
              <common:AnnotationType>Indicator</common:AnnotationType>
              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
            </common:Annotation>
            <common:Annotation>
              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
              <common:AnnotationType>Indicator</common:AnnotationType>
              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
            </common:Annotation>

After pasting, each instance should look like this:

            <common:Annotation>
              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
              <common:AnnotationType>Indicator</common:AnnotationType>
              <common:AnnotationText xml:lang="en">1.5.1</common:AnnotationText>
            </common:Annotation>
            <common:Annotation>
              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
              <common:AnnotationType>Indicator</common:AnnotationType>
              <common:AnnotationText xml:lang="en">11.5.1</common:AnnotationText>
            </common:Annotation>
            <common:Annotation>
              <common:AnnotationTitle>Indicator</common:AnnotationTitle>
              <common:AnnotationType>Indicator</common:AnnotationType>
              <common:AnnotationText xml:lang="en">13.1.1</common:AnnotationText>
            </common:Annotation>