### PR TITLE
Fix series name SI_COV_MATNL under Indicator 1.3.1

### DIFF
--- a/RWA_2025_SDG DSD.xml
+++ b/RWA_2025_SDG DSD.xml
@@ -2820,7 +2820,7 @@
           <common:Name xml:lang="en">Percentage of the population accessing social security and income support programmes</common:Name>
           <common:Description xml:lang="en">Percentage of the population accessing social security and income support programmes</common:Description>
         </structure:Code>
-        <structure:Code id="SI_COV_MATL">
+        <structure:Code id="SI_COV_MATNL">
           <common:Annotations>
             <common:Annotation>
               <common:AnnotationTitle>Indicator</common:AnnotationTitle>

--- a/sdmx-data/2025_RWA-SDG_Data.xml
+++ b/sdmx-data/2025_RWA-SDG_Data.xml
@@ -2,7 +2,7 @@
 <!--Created with SDMX Converter v11.8.3-->
 <message:StructureSpecificData xmlns:ss="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/data/structurespecific" xmlns:footer="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message/footer" xmlns:ns1="urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=NISR-SDGs:SDG(1.3):ObsLevelDim:TIME_PERIOD" xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xml="http://www.w3.org/XML/1998/namespace">
   <message:Header>
-    <message:ID>IREF1779285617045</message:ID>
+    <message:ID>IREF1779287151929</message:ID>
     <message:Test>false</message:Test>
     <message:Prepared>2026-05-20T00:00:00Z</message:Prepared>
     <message:Sender id="BIS"/>


### PR DESCRIPTION
- Correct series name `SI_COV_MATNL` which had been mistakenly entered as `SI_COV_MATL`